### PR TITLE
fix: remove unused pytest import in test_merge.py

### DIFF
--- a/tests/unit/utils/test_merge.py
+++ b/tests/unit/utils/test_merge.py
@@ -2,7 +2,6 @@
 # coding: utf-8 -*-
 
 """Unit tests for deep_merge utility."""
-import pytest
 from avd_cli.utils.merge import deep_merge
 
 


### PR DESCRIPTION
## Description

This PR fixes the CI lint failure in run #21009091208 on the main branch.

## Problem

The workflow `code-testing` failed with:
```
tests/unit/utils/test_merge.py:5:1: F401 'pytest' imported but unused
```

## Solution

- Remove unused `pytest` import from `tests/unit/utils/test_merge.py`
- No functional changes to the tests themselves
- All 6 tests in the file continue to pass

## Validation

✅ `flake8` passes without errors
✅ All tests pass (6/6)
✅ `make ci-lint` passes with pylint score 9.99/10

## Related

- Fixes CI run: #21009091208
- Commit: 18a7d09971b83cc3114ce3e3092e4e1aca0272e9